### PR TITLE
Fix for Symfony 4.1.10

### DIFF
--- a/Finder/ClassFileFinder.php
+++ b/Finder/ClassFileFinder.php
@@ -39,7 +39,7 @@ class ClassFileFinder
 
     protected function applyExcludePathnamePattern(Finder $finder)
     {
-        if($this->excludePathnamePattern === null){
+        if($this->excludePathnamePattern === null || $this->excludePathnamePattern === []){
             return;
         }
         $finder->notName($this->excludePathnamePattern);
@@ -71,7 +71,7 @@ class ClassFileFinder
 
     protected function applyExcludeDirPattern(Finder $finder)
     {
-        if($this->excludeDirPattern === null){
+        if($this->excludeDirPattern === null || $this->excludeDirPattern === []){
             return;
         }
         $finder->notPath($this->excludeDirPattern);


### PR DESCRIPTION
The Symfony 4.1.10 cannot start, because Symfony Finder return the empty array instead of null value, which is necessary to working properly the bundle.