### PR TITLE
Fix error when using inherited service classes

### DIFF
--- a/Converter/Parser/ClassParser.php
+++ b/Converter/Parser/ClassParser.php
@@ -26,6 +26,7 @@ class ClassParser
         $this->parseClass($classMeta);
         $this->parseMethod($classMeta);
         $this->parseProperty($classMeta);
+        $this->parseParent($classMeta);
     }
 
     protected function parseParent(ClassMeta $classMeta)


### PR DESCRIPTION
For some reason parent classes were not parsed, which resulted in the following error when defining a service that inherits from another one:
```
In ContainerBuilder.php line 842:
                                                                              
  [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]  
  Invalid alias id: "".            
```