### PR TITLE
Fix error when using inherited service classes

### DIFF
--- a/Converter/DefinitionConverter.php
+++ b/Converter/DefinitionConverter.php
@@ -63,6 +63,7 @@ class DefinitionConverter
 
         if($classMeta->parent){
             $definition = new ChildDefinition($classMeta->parent);
+            $definition->setClass($classMeta->class);
         }
         else {
             $definition = new Definition($classMeta->class);


### PR DESCRIPTION
When using service inheritance, like
```php
/**
 * @Di\Service("app.my_service", parent="app.my_parent_service", public=false)
 **/
```

the following error would occur:
```
In ContainerBuilder.php line 842:
                                                                              
  [Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]  
  Invalid alias id: "".            
```
Which comes from AnnotationCompilerPass.php:88

I don't know if this is the right way to fix it, but at least it seems to work.